### PR TITLE
keras-tuner 1.4.7

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/kt-legacy-feedstock/pr1/8d1a971

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/kt-legacy-feedstock/pr1/8d1a971

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,10 +34,10 @@ requirements:
 test:
   imports:
     - keras_tuner
-    - keras_tuner.applications  # [not win and not s390x]
-    - keras_tuner.engine  # [not win and not s390x]
-    - keras_tuner.oracles  # [not win and not s390x]
-    - keras_tuner.tuners  # [not win and not s390x]
+    - keras_tuner.applications  # [not (win or s390x)]
+    - keras_tuner.engine  # [not (win or s390x)]
+    - keras_tuner.oracles  # [not (win or s390x)]
+    - keras_tuner.tuners  # [not (win or s390x)]
   commands:
     - pip check
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,35 +10,32 @@ source:
   sha256: 6befd25ee81476e6207d8ca7ed7dc674b8194437cfa0b127294cd00da905ff22
 
 build:
-  noarch: python
-  number: 1
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: True  # [py<37]
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python
+    - setuptools
+    - wheel
   run:
-    - python >=3.7
-    - Ipython
-    - kt-legacy
-    - numpy
+    - python
+    - keras
     - packaging
     - requests
-    - scikit-learn
-    - scipy
-    - tensorboard
+    - kt-legacy
     - tensorflow >=2.0
-
+    - tensorflow-cpu >=2.0
+  run_constrained:
 
 test:
   imports:
     - keras_tuner
     - keras_tuner.applications
-    - keras_tuner.distribute
     - keras_tuner.engine
     - keras_tuner.oracles
-    - keras_tuner.protos
     - keras_tuner.tuners
   commands:
     - pip check
@@ -51,6 +48,7 @@ about:
   license_family: APACHE
   license_file: LICENSE
   summary: Hypertuner for Keras
+  description: KerasTuner is an easy-to-use, scalable hyperparameter optimization framework that solves the pain points of hyperparameter search.
   doc_url: https://keras-team.github.io/keras-tuner/
   dev_url: https://github.com/keras-team/keras-tuner
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     # extras
     - tensorflow >=2.0
     - tensorflow-cpu >=2.0  # [linux]
+    - pytorch  # [osx]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,15 +22,16 @@ requirements:
     - wheel
   run:
     - python
-    - Ipython
-    - kt-legacy
-    - numpy
+    - keras
     - packaging
     - requests
+    - kt-legacy
+    - tensorflow >=2.0
+    - tensorflow-cpu >=2.0
     - scikit-learn
     - scipy
-    - tensorboard
-    - tensorflow >=2.0
+    - namex
+    - build
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,23 +29,37 @@ requirements:
     - requests
     - kt-legacy
     - tensorflow >=2.0
-    - tensorflow-cpu >=2.0
+    - tensorflow-cpu
     - scikit-learn
     - scipy
-    # Required on OSX as Keras 3.x has a hard dependency on PyTorch for certain operations
+    # Required on OSX as Keras 3.x has a hard dependency on PyTorch for certain operations.
+    # This is due to Keras 3.x's multi-backend architecture where some operations on macOS
+    # are optimized to use PyTorch's implementation. See:
+    # https://github.com/keras-team/keras/blob/main/requirements.txt
     - pytorch  # [osx]
+  run_constrained:
+    - tensorflow-base >=2.0
 
 test:
   imports:
     - keras_tuner
     - keras_tuner.applications
+    - keras_tuner.src.backend
+    - keras_tuner.src.distribute
     - keras_tuner.engine
     - keras_tuner.oracles
+    - keras_tuner.src.protos
     - keras_tuner.tuners
   commands:
     - pip check
   requires:
     - pip
+    # - scikit-learn
+    # - scipy
+    # - tensorflow >=2.0
+    # - tensorflow-cpu
+    # - keras
+    # - pytorch  # [osx]
 
 about:
   home: https://github.com/keras-team/keras-tuner

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,22 +22,23 @@ requirements:
     - wheel
   run:
     - python
-    - keras
+    - Ipython
+    - kt-legacy
+    - numpy
     - packaging
     - requests
-    - kt-legacy
-    # extras
-    - tensorflow >=2.0  # [not (win or s390x)]
-    - tensorflow-cpu >=2.0  # [linux and not s390x]
-    - pytorch  # [osx]
+    - scikit-learn
+    - scipy
+    - tensorboard
+    - tensorflow >=2.0
 
 test:
   imports:
-    - keras_tuner  # [not (win or s390x)]
-    - keras_tuner.applications  # [not (win or s390x)]
-    - keras_tuner.engine  # [not (win or s390x)]
-    - keras_tuner.oracles  # [not (win or s390x)]
-    - keras_tuner.tuners  # [not (win or s390x)]
+    - keras_tuner
+    - keras_tuner.applications
+    - keras_tuner.engine
+    - keras_tuner.oracles
+    - keras_tuner.tuners
   commands:
     - pip check
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,6 @@ requirements:
     - requests
     - kt-legacy
     - tensorflow >=2.0
-    - tensorflow-cpu
     - scikit-learn
     - scipy
     # Required on OSX as Keras 3.x has a hard dependency on PyTorch for certain operations.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,8 +27,8 @@ requirements:
     - requests
     - kt-legacy
     - tensorflow >=2.0
-    - tensorflow-cpu >=2.0
   run_constrained:
+    - tensorflow-cpu >=2.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,8 +26,8 @@ requirements:
     - packaging
     - requests
     - kt-legacy
+    # extras
     - tensorflow >=2.0
-  run_constrained:
     - tensorflow-cpu >=2.0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - kt-legacy
     # extras
     - tensorflow >=2.0
-    - pytorch
+    - tensorflow-cpu >=2.0  # [linux]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,6 @@ requirements:
     - kt-legacy
     # extras
     - tensorflow >=2.0
-    - tensorflow-cpu >=2.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,10 +34,10 @@ requirements:
 test:
   imports:
     - keras_tuner
-    - keras_tuner.applications  # [not s390x and win]
-    - keras_tuner.engine  # [not s390x and win]
-    - keras_tuner.oracles  # [not s390x and win]
-    - keras_tuner.tuners  # [not s390x and win]
+    - keras_tuner.applications  # [not win and not (s390x)]
+    - keras_tuner.engine  # [not win and not (s390x)]
+    - keras_tuner.oracles  # [not win and not (s390x)]
+    - keras_tuner.tuners  # [not win and not (s390x)]
   commands:
     - pip check
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,9 @@ requirements:
     - tensorflow-cpu >=2.0
     - scikit-learn
     - scipy
+    # Required on OSX as Keras 3.x defaults to PyTorch backend on this platform
+    # https://keras.io/getting_started/faq/#which-backend-should-i-use
+    - pytorch  # [osx]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,14 +22,10 @@ requirements:
     - wheel
   run:
     - python
-    - Ipython
-    - kt-legacy
-    - numpy
+    - keras
     - packaging
     - requests
-    - scikit-learn
-    - scipy
-    - keras
+    - kt-legacy
     # extras
     - tensorflow >=2.0
     - tensorflow-cpu >=2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,8 @@ source:
   sha256: 6befd25ee81476e6207d8ca7ed7dc674b8194437cfa0b127294cd00da905ff22
 
 build:
-  skip: True  # [py<37]
+  # No tensorflow for python 3.13
+  skip: True  # [py<37 or py>=313]
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - requests
     - kt-legacy
     # extras for test imports
-    - tensorflow >=2.0  # [not s390x]
+    - tensorflow >=2.0  # [not (win or s390x)]
     - tensorflow-cpu >=2.0  # [linux and not s390x]
     - pytorch  # [osx]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "keras-tuner" %}
-{% set version = "1.2.1" %}
+{% set version = "1.4.7" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 21478f73e6f1ce5a34e8b378eb10dc935a5e6e6eb74deb46131cd23653d13422
+  sha256: 6befd25ee81476e6207d8ca7ed7dc674b8194437cfa0b127294cd00da905ff22
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,18 +26,18 @@ requirements:
     - packaging
     - requests
     - kt-legacy
-    # extras
-    - tensorflow >=2.0
+    # extras for test imports
+    - tensorflow >=2.0  # [not win]
     - tensorflow-cpu >=2.0  # [linux]
     - pytorch  # [osx]
 
 test:
   imports:
-    - keras_tuner  # [not s390x]
-    - keras_tuner.applications  # [not s390x]
-    - keras_tuner.engine  # [not s390x]
-    - keras_tuner.oracles  # [not s390x]
-    - keras_tuner.tuners  # [not s390x]
+    - keras_tuner  # [not s390x or win]
+    - keras_tuner.applications  # [not s390x or win]
+    - keras_tuner.engine  # [not s390x or win]
+    - keras_tuner.oracles  # [not s390x or win]
+    - keras_tuner.tuners  # [not s390x or win]
   commands:
     - pip check
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,10 +22,14 @@ requirements:
     - wheel
   run:
     - python
-    - keras
+    - Ipython
+    - kt-legacy
+    - numpy
     - packaging
     - requests
-    - kt-legacy
+    - scikit-learn
+    - scipy
+    - keras
     # extras
     - tensorflow >=2.0
     - tensorflow-cpu >=2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,8 +31,6 @@ requirements:
     - tensorflow-cpu >=2.0
     - scikit-learn
     - scipy
-    - namex
-    - build
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,11 +31,6 @@ requirements:
     - tensorflow >=2.17
     - scikit-learn
     - scipy
-    # Required on OSX as Keras 3.x has a hard dependency on PyTorch for certain operations.
-    # This is due to Keras 3.x's multi-backend architecture where some operations on macOS
-    # are optimized to use PyTorch's implementation. See:
-    # https://github.com/keras-team/keras/blob/main/requirements.txt
-    - pytorch  # [osx]
   run_constrained:
     - tensorflow-base >=2.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - python
     - setuptools
     - wheel
+    - pytorch  # [osx]
   run:
     - python
     - keras

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,14 +26,14 @@ requirements:
     - packaging
     - requests
     - kt-legacy
-    # extras for test imports
+    # extras
     - tensorflow >=2.0  # [not (win or s390x)]
     - tensorflow-cpu >=2.0  # [linux and not s390x]
     - pytorch  # [osx]
 
 test:
   imports:
-    - keras_tuner
+    - keras_tuner  # [not (win or s390x)]
     - keras_tuner.applications  # [not (win or s390x)]
     - keras_tuner.engine  # [not (win or s390x)]
     - keras_tuner.oracles  # [not (win or s390x)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,17 +27,17 @@ requirements:
     - requests
     - kt-legacy
     # extras for test imports
-    - tensorflow >=2.0  # [not win]
-    - tensorflow-cpu >=2.0  # [linux]
+    - tensorflow >=2.0  # [not s390x]
+    - tensorflow-cpu >=2.0  # [linux and not s390x]
     - pytorch  # [osx]
 
 test:
   imports:
     - keras_tuner
-    - keras_tuner.applications  # [not s390x or win]
-    - keras_tuner.engine  # [not s390x or win]
-    - keras_tuner.oracles  # [not s390x or win]
-    - keras_tuner.tuners  # [not s390x or win]
+    - keras_tuner.applications  # [not s390x and win]
+    - keras_tuner.engine  # [not s390x and win]
+    - keras_tuner.oracles  # [not s390x and win]
+    - keras_tuner.tuners  # [not s390x and win]
   commands:
     - pip check
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - kt-legacy
     # extras
     - tensorflow >=2.0
-    - tensorflow-cpu >=2.0
+    - pytorch
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
 
 test:
   imports:
-    - keras_tuner  # [not s390x or win]
+    - keras_tuner
     - keras_tuner.applications  # [not s390x or win]
     - keras_tuner.engine  # [not s390x or win]
     - keras_tuner.oracles  # [not s390x or win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,8 +27,8 @@ requirements:
     - requests
     - kt-legacy
     # extras
-    - tensorflow >=2.0
-    - tensorflow-cpu >=2.0  # [linux]
+    - tensorflow >=2.0  # [not s390x]
+    - tensorflow-cpu >=2.0  # [linux and not s390x]
     - pytorch  # [osx]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,17 +27,17 @@ requirements:
     - requests
     - kt-legacy
     # extras
-    - tensorflow >=2.0  # [not s390x]
-    - tensorflow-cpu >=2.0  # [linux and not s390x]
+    - tensorflow >=2.0
+    - tensorflow-cpu >=2.0  # [linux]
     - pytorch  # [osx]
 
 test:
   imports:
-    - keras_tuner
-    - keras_tuner.applications
-    - keras_tuner.engine
-    - keras_tuner.oracles
-    - keras_tuner.tuners
+    - keras_tuner  # [not s390x]
+    - keras_tuner.applications  # [not s390x]
+    - keras_tuner.engine  # [not s390x]
+    - keras_tuner.oracles  # [not s390x]
+    - keras_tuner.tuners  # [not s390x]
   commands:
     - pip check
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,8 +32,7 @@ requirements:
     - tensorflow-cpu >=2.0
     - scikit-learn
     - scipy
-    # Required on OSX as Keras 3.x defaults to PyTorch backend on this platform
-    # https://keras.io/getting_started/faq/#which-backend-should-i-use
+    # Required on OSX as Keras 3.x has a hard dependency on PyTorch for certain operations
     - pytorch  # [osx]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,12 +54,6 @@ test:
     - pip check
   requires:
     - pip
-    # - scikit-learn
-    # - scipy
-    # - tensorflow >=2.0
-    # - tensorflow-cpu
-    # - keras
-    # - pytorch  # [osx]
 
 about:
   home: https://github.com/keras-team/keras-tuner

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - kt-legacy
     # extras
     - tensorflow >=2.0
+    - tensorflow-cpu >=2.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,10 +34,10 @@ requirements:
 test:
   imports:
     - keras_tuner
-    - keras_tuner.applications  # [not win and not (s390x)]
-    - keras_tuner.engine  # [not win and not (s390x)]
-    - keras_tuner.oracles  # [not win and not (s390x)]
-    - keras_tuner.tuners  # [not win and not (s390x)]
+    - keras_tuner.applications  # [not win and not s390x]
+    - keras_tuner.engine  # [not win and not s390x]
+    - keras_tuner.oracles  # [not win and not s390x]
+    - keras_tuner.tuners  # [not win and not s390x]
   commands:
     - pip check
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - packaging
     - requests
     - kt-legacy
-    - tensorflow >=2.0
+    - tensorflow >=2.17
     - tensorflow-cpu
     - scikit-learn
     - scipy


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-4210](https://anaconda.atlassian.net/browse/PKG-4210)
- [Upstream repository](https://github.com/keras-team/keras-tuner/tree/v1.4.7)
- [Upstream changelog/diff](https://github.com/keras-team/keras-tuner/releases)

### Explanation of changes:

- Update version and sha256
- Linter fixes
- Dependency updates

[PKG-4210]: https://anaconda.atlassian.net/browse/PKG-4210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ