### PR TITLE
keras-tuner 1.4.7 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   # No tensorflow for python 3.13
   skip: True  # [py<37 or py>=313]
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
@@ -21,7 +21,7 @@ requirements:
     - python
     - setuptools
     - wheel
-    - pytorch  # [osx]
+    - pytorch {{ pytorch }}  # [osx]
   run:
     - python
     - keras


### PR DESCRIPTION
keras-tuner 1.4.7 

**Destination channel:** Defaults

### Links

- [PKG-9329]
- dev_url:        https://github.com/keras-team/keras-tuner/tree/v1.4.7
- conda_forge:    https://github.com/conda-forge/keras-tuner-feedstock
- pypi:           https://pypi.org/project/keras-tuner/1.4.7
- pypi inspector: https://inspector.pypi.io/project/keras-tuner/1.4.7

### Explanation of changes:

- rebuild to fix issue after keras update https://github.com/AnacondaRecipes/keras-feedstock/pull/6/files#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9aR36:

> Could not solve for environment specs
The following packages are incompatible
├─ keras =3.11.2 * is installable and it requires
│  └─ pytorch >=2.6.0 *, which can be installed;
└─ pytorch >=2.5.1,<2.6.0a0 * is not installable because it conflicts with any installable versions previously reported.


[PKG-9329]: https://anaconda.atlassian.net/browse/PKG-9329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ